### PR TITLE
Display wpa_gui in the start menu

### DIFF
--- a/usr/share/pt-os-ui-overrides/applications/wpa_gui.desktop
+++ b/usr/share/pt-os-ui-overrides/applications/wpa_gui.desktop
@@ -9,4 +9,3 @@ GenericName=wpa_supplicant user interface
 Terminal=false
 Type=Application
 Categories=Settings;
-NoDisplay=true


### PR DESCRIPTION
| Status  | Ticket/Issue |
| :---: | :--: |
| Ready/Hold | [Ticket](https://pi-top.atlassian.net/browse/SWE-3) |


#### Main changes

Display `wpa_gui` in our start menu as "Wifi configuration" in the "Preferences" section.

#### Screenshots (feature, test output, profiling, dev tools etc)

![image](https://user-images.githubusercontent.com/14126805/152611599-e3a4782f-cedc-4f16-93f9-18e990373ab7.png)

#### Other notes (e.g. implementation quirks, edge cases, questions / issues)
- N/A

#### Manual testing tips
- N/A

#### Tag anyone who definitely needs to review or help
- @angusjfw 
